### PR TITLE
fix: Use spike start time for history in FluviusPeakPowerSensor

### DIFF
--- a/custom_components/fluvius/sensor.py
+++ b/custom_components/fluvius/sensor.py
@@ -311,7 +311,7 @@ class FluviusPeakPowerSensor(CoordinatorEntity[FluviusEnergyDataUpdateCoordinato
         if not data or not latest:
             return None
         history = {
-            peak.period_start.strftime("%Y-%m"): round(peak.value_kw, 3)
+            peak.spike_start.strftime("%Y-%m"): round(peak.value_kw, 3)
             for peak in data.peak_measurements[-12:]
         }
         return {


### PR DESCRIPTION
## Fix: monthly peak history uses wrong month key

The `monthly_peaks_kw` attribute in `FluviusPeakPowerSensor` was keying each entry by `period_start`, which Fluvius sets to the last day of the previous month (in my case). This caused peaks to be attributed to the wrong month.

Changed the key to use `spike_start` instead, which is the actual timestamp of the peak power event (`sst` field in the API response) and therefore the most accurate representation of which month the peak belongs to.
